### PR TITLE
単語、単元テーブルの作成 関連APIの作成

### DIFF
--- a/app/controllers/AuthUtils.rb
+++ b/app/controllers/AuthUtils.rb
@@ -17,7 +17,7 @@ module AuthUtils
     end
 
     def raise_auth_error!
-      render json: { error: t('devise.failure.unauthenticated') }, status: 401
+      render json: { result: false, error: t('devise.failure.unauthenticated') }, status: 401
     end
 
     def current_user

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::API
   include AbstractController::Translation
   include AuthUtils
+  include SerializerUtils
 
   def authenticate_user_from_token!
     auth_token = request.headers['Authorization']

--- a/app/controllers/serializer_utils.rb
+++ b/app/controllers/serializer_utils.rb
@@ -1,0 +1,11 @@
+module SerializerUtils
+
+  def render_success_json(message)
+    render json: { result: true, message: message }
+  end
+
+  def render_failed_json(message)
+    render json: { result: false, message: message }
+  end
+
+end

--- a/app/controllers/v1/unit_masters_controller.rb
+++ b/app/controllers/v1/unit_masters_controller.rb
@@ -9,16 +9,16 @@ module V1
     def create
       unit_master = UnitMaster.create unit_master_params
       if unit_master.save
-        render json: { result: true, message: t('masters.create.success') }
+        render json: { result: true, message: t('unit_masters.create.success') }
       else
-        render json: { result: false, message: t('masters.create.failed') }
+        render json: { result: false, message: t('unit_masters.create.failed') }
       end
     end
 
     def update
       unit_master = UnitMaster.find(params[:id])
       unit_master.update! unit_master_params
-      render json: { result: true, message: t('masters.update.success')}
+      render json: { result: true, message: t('unit_masters.update.success')}
     rescue StandardError
       render json: { result: false, message: t('apis.update_record_not_found') }
     end
@@ -26,8 +26,7 @@ module V1
     private
 
     def unit_master_params
-      params.require(:unit_master).permit(:japanese, :vietnamese)
+      params.permit(:japanese, :vietnamese)
     end
-
   end
 end

--- a/app/controllers/v1/unit_masters_controller.rb
+++ b/app/controllers/v1/unit_masters_controller.rb
@@ -1,0 +1,33 @@
+module V1
+  class UnitMastersController < ApplicationController
+    before_action :authenticated!
+
+    # create unit
+    # @param auth_token
+    # @param japanese
+    # @param vietnamese
+    def create
+      unit_master = UnitMaster.create unit_master_params
+      if unit_master.save
+        render json: { result: true, message: t('masters.create.success') }
+      else
+        render json: { result: false, message: t('masters.create.failed') }
+      end
+    end
+
+    def update
+      unit_master = UnitMaster.find(params[:id])
+      unit_master.update! unit_master_params
+      render json: { result: true, message: t('masters.update.success')}
+    rescue StandardError
+      render json: { result: false, message: t('apis.update_record_not_found') }
+    end
+
+    private
+
+    def unit_master_params
+      params.require(:unit_master).permit(:japanese, :vietnamese)
+    end
+
+  end
+end

--- a/app/controllers/v1/word_masters_controller.rb
+++ b/app/controllers/v1/word_masters_controller.rb
@@ -1,0 +1,4 @@
+module V1
+  class WordMastersController < ApplicationController
+  end
+end

--- a/app/controllers/v1/word_masters_controller.rb
+++ b/app/controllers/v1/word_masters_controller.rb
@@ -4,7 +4,7 @@ module V1
 
     def create
       unless params[:unit_master_id]
-        render json: { result: true, message: t('word_masters.create.specify_unit_master_id') }
+        render_failed_json t('word_masters.create.specify_unit_master_id')
       end
       unit_master = UnitMaster.find(params[:unit_master_id])
       word_master = unit_master.word_masters.create(furigana: params[:furigana],

--- a/app/controllers/v1/word_masters_controller.rb
+++ b/app/controllers/v1/word_masters_controller.rb
@@ -1,4 +1,34 @@
 module V1
   class WordMastersController < ApplicationController
+    before_action :authenticated!
+
+    def create
+      unless params[:unit_master_id]
+        render json: { result: true, message: t('word_masters.create.specify_unit_master_id') }
+      end
+      unit_master = UnitMaster.find(params[:unit_master_id])
+      word_master = unit_master.word_masters.create(furigana: params[:furigana],
+                                                    japanese: params[:japanese],
+                                                    vietnamese: params[:vietnamese],
+                                                    english: params[:english])
+      word_master.save!
+      render_success_json t('word_masters.create.success')
+    rescue StandardError
+      render_failed_json t('word_masters.create.failed')
+    end
+
+    def update
+      word_master = WordMaster.find(params[:id])
+      word_master.update! word_master_params
+      render_success_json t('word_masters.update.success')
+    rescue StandardError
+      render_failed_json t('word_masters.update.failed')
+    end
+
+    private
+
+    def word_master_params
+      params.permit(:furigana, :japanese, :vietnamese, :english)
+    end
   end
 end

--- a/app/models/unit_master.rb
+++ b/app/models/unit_master.rb
@@ -9,6 +9,8 @@
 #  updated_at :datetime         not null
 #
 class UnitMaster < ApplicationRecord
+  has_many :word_masters
+
   validates :japanese, presence: true
   validates :vietnamese, presence: true
 end

--- a/app/models/unit_master.rb
+++ b/app/models/unit_master.rb
@@ -1,0 +1,14 @@
+# == Schema Information
+#
+# Table name: unit_masters
+#
+#  id         :bigint           not null, primary key
+#  japanese   :string(255)      not null
+#  vietnamese :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class UnitMaster < ApplicationRecord
+  validates :japanese, presence: true
+  validates :vietnamese, presence: true
+end

--- a/app/models/word_master.rb
+++ b/app/models/word_master.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: word_masters
+#
+#  id             :bigint           not null, primary key
+#  english        :string(255)      not null
+#  furigana       :string(255)
+#  japanese       :string(255)      not null
+#  vietnamese     :string(255)      not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  unit_master_id :bigint
+#
+# Indexes
+#
+#  index_word_masters_on_unit_master_id  (unit_master_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (unit_master_id => unit_masters.id)
+#
+class WordMaster < ApplicationRecord
+  belongs_to :unit_master
+
+  validates :english, presence: true
+  validates :japanese, presence: true
+  validates :vietnamese, presence: true
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ development:
   database: Japanese_nursing_development
   pool: 5
   username: root
-  password: password
+  password:
   socket: /tmp/mysql.sock
 
 # Warning: The database defined as "test" will be erased and

--- a/config/locales/controllers/unit_masters.yml
+++ b/config/locales/controllers/unit_masters.yml
@@ -1,0 +1,13 @@
+ja:
+  unit_masters:
+    show:
+      not_found: 単元は存在しません。
+    create:
+      success: 単元を作成しました。
+      failed: 単元の保存に失敗しました。
+    update:
+      success: 単元を更新しました。
+      failed: 単元の更新に失敗しました。
+    destroy:
+      success: 単元を削除しました。
+      failed: 単元の削除に失敗しました。

--- a/config/locales/controllers/word_masters.yml
+++ b/config/locales/controllers/word_masters.yml
@@ -1,0 +1,15 @@
+ja:
+  word_masters:
+    show:
+      not_found: masterは存在しません。
+    create:
+      success: 単語を作成しました。
+      failed: 単語の保存に失敗しました。
+      specify_unit_master_id: 単元のIDを指定してください。
+      cannnot_find_unit_master_id: 単元が見つかりません。
+    update:
+      success: 単語を更新しました。
+      failed: 単語の更新に失敗しました。
+    destroy:
+      success: 単語を削除しました。
+      failed: 単語の削除に失敗しました。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,9 @@
 #                                       DELETE /api/v1/masters/:id(.:format)                                                            v1/masters#destroy {:format=>:json}
 #                               v1_user PATCH  /api/v1/users/:id(.:format)                                                              v1/users#update {:format=>:json}
 #                                       PUT    /api/v1/users/:id(.:format)                                                              v1/users#update {:format=>:json}
+#                       v1_unit_masters POST   /api/v1/unit_masters(.:format)                                                           v1/unit_masters#create {:format=>:json}
+#                        v1_unit_master PATCH  /api/v1/unit_masters/:id(.:format)                                                       v1/unit_masters#update {:format=>:json}
+#                                       PUT    /api/v1/unit_masters/:id(.:format)                                                       v1/unit_masters#update {:format=>:json}
 #                             v1_signup POST   /api/v1/signup(.:format)                                                                 v1/users#create {:format=>:json}
 #         rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
 #            rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create
@@ -37,6 +40,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :masters, only: %i[index update show destroy create]
       resources :users, only: %i[update]
+      resources :unit_masters, only: %i[create update]
       resource :signup, only: %i[create], controller: :users
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,9 @@
 #                       v1_unit_masters POST   /api/v1/unit_masters(.:format)                                                           v1/unit_masters#create {:format=>:json}
 #                        v1_unit_master PATCH  /api/v1/unit_masters/:id(.:format)                                                       v1/unit_masters#update {:format=>:json}
 #                                       PUT    /api/v1/unit_masters/:id(.:format)                                                       v1/unit_masters#update {:format=>:json}
+#                       v1_word_masters POST   /api/v1/word_masters(.:format)                                                           v1/word_masters#create {:format=>:json}
+#                        v1_word_master PATCH  /api/v1/word_masters/:id(.:format)                                                       v1/word_masters#update {:format=>:json}
+#                                       PUT    /api/v1/word_masters/:id(.:format)                                                       v1/word_masters#update {:format=>:json}
 #                             v1_signup POST   /api/v1/signup(.:format)                                                                 v1/users#create {:format=>:json}
 #         rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
 #            rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create
@@ -41,6 +44,7 @@ Rails.application.routes.draw do
       resources :masters, only: %i[index update show destroy create]
       resources :users, only: %i[update]
       resources :unit_masters, only: %i[create update]
+      resources :word_masters, only: %i[create update]
       resource :signup, only: %i[create], controller: :users
     end
   end

--- a/db/migrate/20201114053136_create_unit_masters.rb
+++ b/db/migrate/20201114053136_create_unit_masters.rb
@@ -1,0 +1,9 @@
+class CreateUnitMasters < ActiveRecord::Migration[6.0]
+  def change
+    create_table :unit_masters do |t|
+      t.string :japanese, null: false
+      t.string :vietnamese, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201114063044_create_word_masters.rb
+++ b/db/migrate/20201114063044_create_word_masters.rb
@@ -1,0 +1,13 @@
+class CreateWordMasters < ActiveRecord::Migration[6.0]
+  def change
+    create_table :word_masters do |t|
+      t.references :unit_master, foreign_key: true
+
+      t.string :furigana
+      t.string :japanese, null: false
+      t.string :english, null: false
+      t.string :vietnamese, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_14_053136) do
+ActiveRecord::Schema.define(version: 2020_11_14_063044) do
 
   create_table "masters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -43,4 +43,16 @@ ActiveRecord::Schema.define(version: 2020_11_14_053136) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "word_masters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "unit_master_id"
+    t.string "furigana"
+    t.string "japanese", null: false
+    t.string "english", null: false
+    t.string "vietnamese", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["unit_master_id"], name: "index_word_masters_on_unit_master_id"
+  end
+
+  add_foreign_key "word_masters", "unit_masters"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_12_223054) do
+ActiveRecord::Schema.define(version: 2020_11_14_053136) do
 
   create_table "masters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "unit_masters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "japanese", null: false
+    t.string "vietnamese", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/test/controllers/unit_masters_controller_test.rb
+++ b/test/controllers/unit_masters_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UnitMastersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/v1/word_masters_controller_test.rb
+++ b/test/controllers/v1/word_masters_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class V1::WordMastersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/unit_masters.yml
+++ b/test/fixtures/unit_masters.yml
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: unit_masters
+#
+#  id         :bigint           not null, primary key
+#  japanese   :string(255)      not null
+#  vietnamese :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/word_masters.yml
+++ b/test/fixtures/word_masters.yml
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: word_masters
+#
+#  id             :bigint           not null, primary key
+#  english        :string(255)      not null
+#  furigana       :string(255)
+#  japanese       :string(255)      not null
+#  vietnamese     :string(255)      not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  unit_master_id :bigint
+#
+# Indexes
+#
+#  index_word_masters_on_unit_master_id  (unit_master_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (unit_master_id => unit_masters.id)
+#
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/unit_master_test.rb
+++ b/test/models/unit_master_test.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: unit_masters
+#
+#  id         :bigint           not null, primary key
+#  japanese   :string(255)      not null
+#  vietnamese :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+require 'test_helper'
+
+class UnitMasterTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/word_master_test.rb
+++ b/test/models/word_master_test.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: word_masters
+#
+#  id             :bigint           not null, primary key
+#  english        :string(255)      not null
+#  furigana       :string(255)
+#  japanese       :string(255)      not null
+#  vietnamese     :string(255)      not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  unit_master_id :bigint
+#
+# Indexes
+#
+#  index_word_masters_on_unit_master_id  (unit_master_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (unit_master_id => unit_masters.id)
+#
+require 'test_helper'
+
+class WordMasterTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
close #8

 POST /api/v1/unit_masters 単元を作成するAPI
```
auth_token: 認証トークン(必須)
japanese: 日本語(必須)
vietnamese: ベトナム語(必須)
```

PATCH /api/v1/unit_masters/:id 単元を更新するAPI
```
auth_token: 認証トークン(必須)
japanese: 日本語(任意)
vietnamese: ベトナム語(任意)
```

POST /api/v1/word_masters 単語を作成するAPI
```
auth_token: 認証トークン(必須)
unit_master_id: 紐づく単元ID(必須)
furigana: ふりがな(任意)
english: 英語(必須)
japanese: 日本語(必須)
vietnamese: ベトナム語(必須)
```

PATCH /api/v1/word_masters/:id 単語を更新するAPI
```
auth_token: 認証トークン(必須)
furigana: ふりがな(任意)
english: 英語(任意)
japanese: 日本語(任意)
vietnamese: ベトナム語(任意)
```