### PR TITLE
ユーザー作成周り調整

### DIFF
--- a/app/controllers/logic/users.rb
+++ b/app/controllers/logic/users.rb
@@ -1,14 +1,29 @@
 module Logic
   module Users
 
-    # Create guest user record.
-    # @return user instance.
+    # ゲストユーザーを作成する
+    # @param user_name ユーザー名
+    # @return ゲストユーザーのインスタンス
     def create_guest_user(user_name)
       guest_user = User.new(user_name: user_name,
                             email: "guest_#{Time.now.to_i}#{rand(100)}@example.com")
-      guest_user.auth_token = Devise.friendly_token
+      guest_user.add_auth_token
       guest_user.save!(validate: false)
       guest_user
+    end
+
+    # 通常ユーザーを作成する
+    # @param email メールアドレス
+    # @param password パスワード
+    # @param user_name ユーザー名
+    # @return 通常ユーザーのインスタンス
+    def create_user(email, password, user_name)
+      user = User.new(email: email,
+                      password: password,
+                      user_name: user_name,
+                      role: 1)
+      user.add_auth_token
+      user if user.save
     end
   end
 end

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -2,9 +2,22 @@ module V1
   class UsersController < ApplicationController
     include Logic::Users
 
+    # create guest or normal user.
+    # @param is_anonymous 匿名ユーザーかどうか
+    # @param user_name ユーザー名
+    # @param email メールアドレス
+    # @param password パスワード
     def create
-      users = create_guest_user params[:user_name]
-      render json: users, each_serializer: UsersSerializer
+      user = if params[:is_anonymous]
+               create_guest_user params[:user_name]
+             else
+               create_user(params[:email], params[:password], params[:user_name])
+             end
+      if user
+        render json: user, serializer: DefaultSerializer
+      else
+        render_failed_json t('users.create.failed_user_create')
+      end
     end
 
     def update

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,7 @@
 #  last_sign_in_ip        :string(255)
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string(255)
+#  role                   :integer          default("anonymous")
 #  sign_in_count          :integer          default(0), not null
 #  user_name              :string(255)
 #  created_at             :datetime         not null
@@ -26,6 +27,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :validatable, :trackable,
          authentication_keys: [:login]
+
+  enum role: { anonymous: 0, registered: 1, admin: 2 }
 
   validates :user_name, length: {
     minimum: 1, maximum: 12

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,9 +28,13 @@ class User < ApplicationRecord
          :validatable, :trackable,
          authentication_keys: [:login]
 
-  enum role: { anonymous: 0, registered: 1, admin: 2 }
+  enum role: { anonymous: 0, normal: 1, admin: 2 }
 
   validates :user_name, length: {
     minimum: 1, maximum: 12
   }, presence: true
+
+  def add_auth_token
+    self.auth_token = Devise.friendly_token
+  end
 end

--- a/config/locales/controllers/users.yml
+++ b/config/locales/controllers/users.yml
@@ -1,0 +1,4 @@
+ja:
+  users:
+    create:
+      failed_user_create: ユーザーの作成に失敗しました

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@
 #                                       PATCH  /api/v1/masters/:id(.:format)                                                            v1/masters#update {:format=>:json}
 #                                       PUT    /api/v1/masters/:id(.:format)                                                            v1/masters#update {:format=>:json}
 #                                       DELETE /api/v1/masters/:id(.:format)                                                            v1/masters#destroy {:format=>:json}
+#                              v1_users POST   /api/v1/users(.:format)                                                                  v1/users#create {:format=>:json}
 #                               v1_user PATCH  /api/v1/users/:id(.:format)                                                              v1/users#update {:format=>:json}
 #                                       PUT    /api/v1/users/:id(.:format)                                                              v1/users#update {:format=>:json}
 #                       v1_unit_masters POST   /api/v1/unit_masters(.:format)                                                           v1/unit_masters#create {:format=>:json}
@@ -42,7 +43,7 @@ Rails.application.routes.draw do
   scope :api, defaults: { format: :json } do
     namespace :v1 do
       resources :masters, only: %i[index update show destroy create]
-      resources :users, only: %i[update]
+      resources :users, only: %i[create update]
       resources :unit_masters, only: %i[create update]
       resources :word_masters, only: %i[create update]
       resource :signup, only: %i[create], controller: :users

--- a/db/migrate/20201121042112_add_to_users_role_column.rb
+++ b/db/migrate/20201121042112_add_to_users_role_column.rb
@@ -1,0 +1,5 @@
+class AddToUsersRoleColumn < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :role, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_14_063044) do
+ActiveRecord::Schema.define(version: 2020_11_21_042112) do
 
   create_table "masters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2020_11_14_063044) do
     t.datetime "updated_at", precision: 6, null: false
     t.string "auth_token", null: false
     t.string "user_name"
+    t.integer "role", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,6 +12,7 @@
 #  last_sign_in_ip        :string(255)
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string(255)
+#  role                   :integer          default("anonymous")
 #  sign_in_count          :integer          default(0), not null
 #  user_name              :string(255)
 #  created_at             :datetime         not null

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -12,6 +12,7 @@
 #  last_sign_in_ip        :string(255)
 #  reset_password_sent_at :datetime
 #  reset_password_token   :string(255)
+#  role                   :integer          default("anonymous")
 #  sign_in_count          :integer          default(0), not null
 #  user_name              :string(255)
 #  created_at             :datetime         not null


### PR DESCRIPTION
### 関連Issue
close #18 

### 概要
- ユーザー作成APIの修正
    - Jsonのレスポンスを修正
    - role追加 
        - 0: 匿名ユーザー
        - 1: 通常ユーザー
        - 2: 管理者ユーザー
    - メールアドレスとパスワードを用いた認証を追加。ログインAPIはまだ未実装

### @POST /api/v1/usersの仕様

- 匿名ユーザーを作成する時
```
is_anonymousに何か指定
user_nameに名前を指定
```

レスポンス
```
{
    "result": true,
    "message": "取得しました。",
    "body": {
        "id": 12,
        "email": "guest_160593667136@example.com",
        "created_at": "2020-11-21T14:31:11.959+09:00",
        "updated_at": "2020-11-21T14:31:11.959+09:00",
        "auth_token": "Y8WxFtzCdt4FovZAiDyt",
        "user_name": "匿名だよ",
        "role": "anonymous"
    }
}
```

- 通常ユーザーを作成する時
```
user_name 名前を指定
email メールアドレスを指定
password パスワードを指定
```

レスポンス
```
{
    "result": true,
    "message": "取得しました。",
    "body": {
        "id": 10,
        "email": "aaaa@aaa.com",
        "created_at": "2020-11-21T14:26:18.651+09:00",
        "updated_at": "2020-11-21T14:26:18.651+09:00",
        "auth_token": "K3CTwvfbY4w6Yt-YkMNW",
        "user_name": "匿名じゃないよ",
        "role": "normal"
    }
}
```
