### PR TITLE
テスト履歴

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'annotate', '~> 3.1.1'
 gem 'rails-i18n', '~> 6.0.0'
 gem 'devise-i18n', '~> 1.9.2'
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'activerecord-import', '~>1.0.7'
 
 # Authentication
 gem 'devise', '~> 4.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,8 @@ GEM
     activerecord (6.0.3.4)
       activemodel (= 6.0.3.4)
       activesupport (= 6.0.3.4)
+    activerecord-import (1.0.7)
+      activerecord (>= 3.2)
     activestorage (6.0.3.4)
       actionpack (= 6.0.3.4)
       activejob (= 6.0.3.4)
@@ -184,6 +186,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
+  activerecord-import (~> 1.0.7)
   annotate (~> 3.1.1)
   bootsnap (>= 1.4.2)
   byebug

--- a/app/controllers/logic/test_histories.rb
+++ b/app/controllers/logic/test_histories.rb
@@ -6,7 +6,6 @@ module Logic
       targets.each do |id|
         tmp << TestHistory.new(user_id: current_user_id, word_master_id: id, is_correct_answer: is_correct_answer)
       end
-
       TestHistory.import tmp
     end
 

--- a/app/controllers/logic/test_histories.rb
+++ b/app/controllers/logic/test_histories.rb
@@ -1,0 +1,14 @@
+module Logic
+  module TestHistories
+
+    def save_history_together(current_user_id, targets, is_correct_answer)
+      tmp = []
+      targets.each do |id|
+        tmp << TestHistory.new(user_id: current_user_id, word_master_id: id, is_correct_answer: is_correct_answer)
+      end
+
+      TestHistory.import tmp
+    end
+
+  end
+end

--- a/app/controllers/v1/test_histories_controller.rb
+++ b/app/controllers/v1/test_histories_controller.rb
@@ -1,8 +1,21 @@
 module V1
   class TestHistoriesController < ApplicationController
+    include Logic::TestHistories
+    before_action :authenticated!
 
     def create
-
+      ActiveRecord::Base.transaction do
+        if params[:correct_ids]
+          save_history_together(current_user.id, params[:correct_ids].split(','), true)
+        end
+        if params[:mistake_ids]
+          save_history_together(current_user.id, params[:mistake_ids].split(','), false)
+        end
+      end
+      render_success_json t('test_histories.create.success')
+    rescue StandardError
+      render_failed_json t('test_histories.create.failed')
     end
+
   end
 end

--- a/app/controllers/v1/test_histories_controller.rb
+++ b/app/controllers/v1/test_histories_controller.rb
@@ -1,0 +1,8 @@
+module V1
+  class TestHistoriesController < ApplicationController
+
+    def create
+
+    end
+  end
+end

--- a/app/models/test_history.rb
+++ b/app/models/test_history.rb
@@ -3,7 +3,7 @@
 # Table name: test_histories
 #
 #  id                :bigint           not null, primary key
-#  is_collect_answer :boolean          not null
+#  is_correct_answer :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  user_id           :bigint
@@ -23,5 +23,5 @@ class TestHistory < ApplicationRecord
   belongs_to :user
   belongs_to :word_master
 
-  validates :is_collect_answer, presence: true
+  validates :is_correct_answer, presence: true
 end

--- a/app/models/test_history.rb
+++ b/app/models/test_history.rb
@@ -1,0 +1,27 @@
+# == Schema Information
+#
+# Table name: test_histories
+#
+#  id                :bigint           not null, primary key
+#  is_collect_answer :boolean          not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :bigint
+#  word_master_id    :bigint
+#
+# Indexes
+#
+#  index_test_histories_on_user_id         (user_id)
+#  index_test_histories_on_word_master_id  (word_master_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (word_master_id => word_masters.id)
+#
+class TestHistory < ApplicationRecord
+  belongs_to :user
+  belongs_to :word_master
+
+  validates :is_collect_answer, presence: true
+end

--- a/app/models/test_history.rb
+++ b/app/models/test_history.rb
@@ -22,6 +22,4 @@
 class TestHistory < ApplicationRecord
   belongs_to :user
   belongs_to :word_master
-
-  validates :is_correct_answer, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,8 @@ class User < ApplicationRecord
          :validatable, :trackable,
          authentication_keys: [:login]
 
+  has_many :test_histories
+
   enum role: { anonymous: 0, normal: 1, admin: 2 }
 
   validates :user_name, length: {

--- a/app/models/word_master.rb
+++ b/app/models/word_master.rb
@@ -20,6 +20,7 @@
 #  fk_rails_...  (unit_master_id => unit_masters.id)
 #
 class WordMaster < ApplicationRecord
+  has_many :test_histories
   belongs_to :unit_master
 
   validates :english, presence: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module JapaneseNursing
     config.api_only = true
 
     config.time_zone = 'Tokyo'
-    config.active_record.default_timezone = :locale
+    config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end

--- a/config/locales/controllers/test_histories.yml
+++ b/config/locales/controllers/test_histories.yml
@@ -1,0 +1,5 @@
+ja:
+  test_histories:
+    create:
+      success: テスト履歴の保存に成功しました。
+      failed: テスト履歴の保存に失敗しました。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[create update]
       resources :unit_masters, only: %i[create update]
       resources :word_masters, only: %i[create update]
+      resources :test_histories, only: %i[create]
       resource :signup, only: %i[create], controller: :users
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@
 #                       v1_word_masters POST   /api/v1/word_masters(.:format)                                                           v1/word_masters#create {:format=>:json}
 #                        v1_word_master PATCH  /api/v1/word_masters/:id(.:format)                                                       v1/word_masters#update {:format=>:json}
 #                                       PUT    /api/v1/word_masters/:id(.:format)                                                       v1/word_masters#update {:format=>:json}
+#                     v1_test_histories POST   /api/v1/test_histories(.:format)                                                         v1/test_histories#create {:format=>:json}
 #                             v1_signup POST   /api/v1/signup(.:format)                                                                 v1/users#create {:format=>:json}
 #         rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
 #            rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create

--- a/db/migrate/20201121112041_create_test_histories.rb
+++ b/db/migrate/20201121112041_create_test_histories.rb
@@ -1,0 +1,11 @@
+class CreateTestHistories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :test_histories do |t|
+      t.references :word_master, foreign_key: true
+      t.references :user, foreign_key: true
+
+      t.boolean :is_collect_answer, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20201121112041_create_test_histories.rb
+++ b/db/migrate/20201121112041_create_test_histories.rb
@@ -4,7 +4,7 @@ class CreateTestHistories < ActiveRecord::Migration[6.0]
       t.references :word_master, foreign_key: true
       t.references :user, foreign_key: true
 
-      t.boolean :is_collect_answer, null: false
+      t.boolean :is_correct_answer, default: false, null: false
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,12 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_21_042112) do
+ActiveRecord::Schema.define(version: 2020_11_21_112041) do
 
   create_table "masters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "test_histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "word_master_id"
+    t.bigint "user_id"
+    t.boolean "is_collect_answer", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_test_histories_on_user_id"
+    t.index ["word_master_id"], name: "index_test_histories_on_word_master_id"
   end
 
   create_table "unit_masters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -55,5 +65,7 @@ ActiveRecord::Schema.define(version: 2020_11_21_042112) do
     t.index ["unit_master_id"], name: "index_word_masters_on_unit_master_id"
   end
 
+  add_foreign_key "test_histories", "users"
+  add_foreign_key "test_histories", "word_masters"
   add_foreign_key "word_masters", "unit_masters"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 2020_11_21_112041) do
   create_table "test_histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "word_master_id"
     t.bigint "user_id"
-    t.boolean "is_collect_answer", null: false
+    t.boolean "is_correct_answer", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_test_histories_on_user_id"

--- a/test/controllers/v1/test_histories_controller_test.rb
+++ b/test/controllers/v1/test_histories_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class V1::TestHistoriesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/test_histories.yml
+++ b/test/fixtures/test_histories.yml
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: test_histories
+#
+#  id                :bigint           not null, primary key
+#  is_collect_answer :boolean          not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :bigint
+#  word_master_id    :bigint
+#
+# Indexes
+#
+#  index_test_histories_on_user_id         (user_id)
+#  index_test_histories_on_word_master_id  (word_master_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (word_master_id => word_masters.id)
+#
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/test_histories.yml
+++ b/test/fixtures/test_histories.yml
@@ -3,7 +3,7 @@
 # Table name: test_histories
 #
 #  id                :bigint           not null, primary key
-#  is_collect_answer :boolean          not null
+#  is_correct_answer :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  user_id           :bigint

--- a/test/models/test_history_test.rb
+++ b/test/models/test_history_test.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: test_histories
+#
+#  id                :bigint           not null, primary key
+#  is_collect_answer :boolean          not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  user_id           :bigint
+#  word_master_id    :bigint
+#
+# Indexes
+#
+#  index_test_histories_on_user_id         (user_id)
+#  index_test_histories_on_word_master_id  (word_master_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (word_master_id => word_masters.id)
+#
+require 'test_helper'
+
+class TestHistoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/test_history_test.rb
+++ b/test/models/test_history_test.rb
@@ -3,7 +3,7 @@
 # Table name: test_histories
 #
 #  id                :bigint           not null, primary key
-#  is_collect_answer :boolean          not null
+#  is_correct_answer :boolean          default(FALSE), not null
 #  created_at        :datetime         not null
 #  updated_at        :datetime         not null
 #  user_id           :bigint


### PR DESCRIPTION
### 関連issue
close #9 

### 概要
- [ ] test_historiesテーブル作成
- [ ] テスト履歴を作成するAPIを作成

### API仕様
@POST /api/v1/test_histories
**auth_token** 本人の認証トークン
**correct_ids** 正解した単語IDを,区切りで指定(例: 1,2,3)
**mistake_ids** 不正解だった単語IDを,区切りで指定
