### PR TITLE
学習履歴を保存するテーブルAPI 作成

### DIFF
--- a/app/controllers/logic/learning_histories.rb
+++ b/app/controllers/logic/learning_histories.rb
@@ -1,0 +1,13 @@
+module Logic
+  module LearningHistories
+
+    def save_history_together(current_user_id, targets, is_remember)
+      tmp = []
+      targets.each do |id|
+        tmp << LearningHistory.new(user_id: current_user_id, word_master_id: id, is_remember: is_remember)
+      end
+      LearningHistory.import tmp
+    end
+
+  end
+end

--- a/app/controllers/v1/learning_histories_controller.rb
+++ b/app/controllers/v1/learning_histories_controller.rb
@@ -1,0 +1,21 @@
+module V1
+  class LearningHistoriesController < ApplicationController
+    include Logic::LearningHistories
+    before_action :authenticated!
+
+    def create
+      ActiveRecord::Base.transaction do
+        if params[:remember_ids]
+          save_history_together(current_user.id, params[:remember_ids].split(','), true)
+        end
+        if params[:not_remember_ids]
+          save_history_together(current_user.id, params[:not_remember_ids].split(','), false)
+        end
+      end
+      render_success_json t('learning_histories.create.success')
+    rescue StandardError
+      render_failed_json t('learning_histories.create.failed')
+    end
+
+  end
+end

--- a/app/models/learning_history.rb
+++ b/app/models/learning_history.rb
@@ -1,0 +1,25 @@
+# == Schema Information
+#
+# Table name: learning_histories
+#
+#  id             :bigint           not null, primary key
+#  is_remember    :boolean          default(FALSE), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  user_id        :bigint
+#  word_master_id :bigint
+#
+# Indexes
+#
+#  index_learning_histories_on_user_id         (user_id)
+#  index_learning_histories_on_word_master_id  (word_master_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (word_master_id => word_masters.id)
+#
+class LearningHistory < ApplicationRecord
+  belongs_to :user
+  belongs_to :word_master
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -29,6 +29,7 @@ class User < ApplicationRecord
          authentication_keys: [:login]
 
   has_many :test_histories
+  has_many :learning_histories
 
   enum role: { anonymous: 0, normal: 1, admin: 2 }
 

--- a/app/models/word_master.rb
+++ b/app/models/word_master.rb
@@ -21,6 +21,7 @@
 #
 class WordMaster < ApplicationRecord
   has_many :test_histories
+  has_many :learning_histories
   belongs_to :unit_master
 
   validates :english, presence: true

--- a/config/locales/controllers/learning_histories.yml
+++ b/config/locales/controllers/learning_histories.yml
@@ -1,0 +1,5 @@
+ja:
+  learning_histories:
+    create:
+      success: 学習履歴の保存に成功しました。
+      failed: 学習履歴の保存に失敗しました。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@
 #                        v1_word_master PATCH  /api/v1/word_masters/:id(.:format)                                                       v1/word_masters#update {:format=>:json}
 #                                       PUT    /api/v1/word_masters/:id(.:format)                                                       v1/word_masters#update {:format=>:json}
 #                     v1_test_histories POST   /api/v1/test_histories(.:format)                                                         v1/test_histories#create {:format=>:json}
+#                 v1_learning_histories POST   /api/v1/learning_histories(.:format)                                                     v1/learning_histories#create {:format=>:json}
 #                             v1_signup POST   /api/v1/signup(.:format)                                                                 v1/users#create {:format=>:json}
 #         rails_postmark_inbound_emails POST   /rails/action_mailbox/postmark/inbound_emails(.:format)                                  action_mailbox/ingresses/postmark/inbound_emails#create
 #            rails_relay_inbound_emails POST   /rails/action_mailbox/relay/inbound_emails(.:format)                                     action_mailbox/ingresses/relay/inbound_emails#create
@@ -48,6 +49,7 @@ Rails.application.routes.draw do
       resources :unit_masters, only: %i[create update]
       resources :word_masters, only: %i[create update]
       resources :test_histories, only: %i[create]
+      resources :learning_histories, only: %i[create]
       resource :signup, only: %i[create], controller: :users
     end
   end

--- a/db/migrate/20201123013705_create_learning_histories.rb
+++ b/db/migrate/20201123013705_create_learning_histories.rb
@@ -1,0 +1,11 @@
+class CreateLearningHistories < ActiveRecord::Migration[6.0]
+  def change
+    create_table :learning_histories do |t|
+      t.references :word_master, foreign_key: true
+      t.references :user, foreign_key: true
+
+      t.boolean :is_remember, default: false, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_21_112041) do
+ActiveRecord::Schema.define(version: 2020_11_23_013705) do
+
+  create_table "learning_histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "word_master_id"
+    t.bigint "user_id"
+    t.boolean "is_remember", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_learning_histories_on_user_id"
+    t.index ["word_master_id"], name: "index_learning_histories_on_word_master_id"
+  end
 
   create_table "masters", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -65,6 +75,8 @@ ActiveRecord::Schema.define(version: 2020_11_21_112041) do
     t.index ["unit_master_id"], name: "index_word_masters_on_unit_master_id"
   end
 
+  add_foreign_key "learning_histories", "users"
+  add_foreign_key "learning_histories", "word_masters"
   add_foreign_key "test_histories", "users"
   add_foreign_key "test_histories", "word_masters"
   add_foreign_key "word_masters", "unit_masters"

--- a/test/controllers/v1/learning_histories_controller_test.rb
+++ b/test/controllers/v1/learning_histories_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class V1::LearningHistoriesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/learning_histories.yml
+++ b/test/fixtures/learning_histories.yml
@@ -1,0 +1,31 @@
+# == Schema Information
+#
+# Table name: learning_histories
+#
+#  id             :bigint           not null, primary key
+#  is_remember    :boolean          default(FALSE), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  user_id        :bigint
+#  word_master_id :bigint
+#
+# Indexes
+#
+#  index_learning_histories_on_user_id         (user_id)
+#  index_learning_histories_on_word_master_id  (word_master_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (word_master_id => word_masters.id)
+#
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/learning_history_test.rb
+++ b/test/models/learning_history_test.rb
@@ -1,0 +1,28 @@
+# == Schema Information
+#
+# Table name: learning_histories
+#
+#  id             :bigint           not null, primary key
+#  is_remember    :boolean          default(FALSE), not null
+#  created_at     :datetime         not null
+#  updated_at     :datetime         not null
+#  user_id        :bigint
+#  word_master_id :bigint
+#
+# Indexes
+#
+#  index_learning_histories_on_user_id         (user_id)
+#  index_learning_histories_on_word_master_id  (word_master_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#  fk_rails_...  (word_master_id => word_masters.id)
+#
+require 'test_helper'
+
+class LearningHistoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 関連Issue
close #10 

### 概要 
- [ ] 学習履歴を保存するテーブル作成
- [ ] 学習履歴を保存するAPI作成

### API仕様
@POST /api/v1/learning_histories
**auth_token** 認証トークン
**remember_ids** 覚えた単語のIDを,区切りで指定
**not_remember_ids** 覚えられなかった単語IDを,区切りで指定