### PR TITLE
学習の目標テーブル

### DIFF
--- a/app/controllers/v1/user_learning_targets_controller.rb
+++ b/app/controllers/v1/user_learning_targets_controller.rb
@@ -12,8 +12,17 @@ module V1
     end
 
     def update
-
+      user_learning_target = UserLearningTarget.find_by!(user_id: current_user.id)
+      user_learning_target&.update! update_params
+      render_success_json t('user_learning_targets.update.success')
+    rescue StandardError
+      render_failed_json t('user_learning_targets.update.failed')
     end
 
+    private
+
+    def update_params
+      params.permit(:target_learning_count, :target_testing_count)
+    end
   end
 end

--- a/app/controllers/v1/user_learning_targets_controller.rb
+++ b/app/controllers/v1/user_learning_targets_controller.rb
@@ -1,0 +1,19 @@
+module V1
+  class UserLearningTargetsController < ApplicationController
+    before_action :authenticated!
+
+    def show
+      user_learning_target = UserLearningTarget.find_by(user_id: current_user.id)
+      if user_learning_target
+        render json: user_learning_target, serializer: UserLearningTargetSerializer
+      else
+        render_failed_json t('user_learning_targets.show.failed')
+      end
+    end
+
+    def update
+
+    end
+
+  end
+end

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -13,7 +13,10 @@ module V1
              else
                create_user(params[:email], params[:password], params[:user_name])
              end
-      if user
+      user_learning_target = UserLearningTarget.new(user_id: user.id,
+                                                    target_learning_count: 30,
+                                                    target_testing_count: 30)
+      if user && user_learning_target.save
         render json: user, serializer: DefaultSerializer
       else
         render_failed_json t('users.create.failed_user_create')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -30,6 +30,7 @@ class User < ApplicationRecord
 
   has_many :test_histories
   has_many :learning_histories
+  has_one :user_learning_target
 
   enum role: { anonymous: 0, normal: 1, admin: 2 }
 

--- a/app/models/user_learning_target.rb
+++ b/app/models/user_learning_target.rb
@@ -19,4 +19,9 @@
 #
 class UserLearningTarget < ApplicationRecord
   belongs_to :user
+
+  validates :target_learning_count,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 10000 }
+  validates :target_testing_count,
+            numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 10000 }
 end

--- a/app/models/user_learning_target.rb
+++ b/app/models/user_learning_target.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: user_learning_targets
+#
+#  id                    :bigint           not null, primary key
+#  target_learning_count :integer          default(0), not null
+#  target_testing_count  :integer          default(0), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  user_id               :bigint
+#
+# Indexes
+#
+#  index_user_learning_targets_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+class UserLearningTarget < ApplicationRecord
+  belongs_to :user
+end

--- a/app/serializers/v1/user_learning_target_serializer.rb
+++ b/app/serializers/v1/user_learning_target_serializer.rb
@@ -1,0 +1,13 @@
+module V1
+  class UserLearningTargetSerializer < ActiveModel::Serializer
+    attributes :result, :message, :id, :target_learning_count, :target_testing_count, :created_at, :updated_at
+
+    def result
+      true
+    end
+
+    def message
+      "取得しました。"
+    end
+  end
+end

--- a/config/locales/controllers/user_learning_histories.yml
+++ b/config/locales/controllers/user_learning_histories.yml
@@ -1,0 +1,4 @@
+ja:
+  user_learning_targets:
+    show:
+      failed: 目標の取得に失敗しました。

--- a/config/locales/controllers/user_learning_histories.yml
+++ b/config/locales/controllers/user_learning_histories.yml
@@ -2,3 +2,6 @@ ja:
   user_learning_targets:
     show:
       failed: 目標の取得に失敗しました。
+    update:
+      success: 目標の更新に成功しました。
+      failed: 目標の更新に失敗しました。

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,9 @@
 #                              v1_users POST   /api/v1/users(.:format)                                                                  v1/users#create {:format=>:json}
 #                               v1_user PATCH  /api/v1/users/:id(.:format)                                                              v1/users#update {:format=>:json}
 #                                       PUT    /api/v1/users/:id(.:format)                                                              v1/users#update {:format=>:json}
-#               v1_user_learning_target PATCH  /api/v1/user_learning_targets/:id(.:format)                                              v1/user_learning_targets#update {:format=>:json}
-#                                       PUT    /api/v1/user_learning_targets/:id(.:format)                                              v1/user_learning_targets#update {:format=>:json}
 #              v1_user_learning_targets GET    /api/v1/user_learning_targets(.:format)                                                  v1/user_learning_targets#show {:format=>:json}
+#                                       PATCH  /api/v1/user_learning_targets(.:format)                                                  v1/user_learning_targets#update {:format=>:json}
+#                                       PUT    /api/v1/user_learning_targets(.:format)                                                  v1/user_learning_targets#update {:format=>:json}
 #                       v1_unit_masters POST   /api/v1/unit_masters(.:format)                                                           v1/unit_masters#create {:format=>:json}
 #                        v1_unit_master PATCH  /api/v1/unit_masters/:id(.:format)                                                       v1/unit_masters#update {:format=>:json}
 #                                       PUT    /api/v1/unit_masters/:id(.:format)                                                       v1/unit_masters#update {:format=>:json}
@@ -49,8 +49,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :masters, only: %i[index update show destroy create]
       resources :users, only: %i[create update]
-      resources :user_learning_targets, only: %i[update]
-      resource :user_learning_targets, only: %i[show]
+      resource :user_learning_targets, only: %i[show update]
       resources :unit_masters, only: %i[create update]
       resources :word_masters, only: %i[create update]
       resources :test_histories, only: %i[create]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,9 @@
 #                              v1_users POST   /api/v1/users(.:format)                                                                  v1/users#create {:format=>:json}
 #                               v1_user PATCH  /api/v1/users/:id(.:format)                                                              v1/users#update {:format=>:json}
 #                                       PUT    /api/v1/users/:id(.:format)                                                              v1/users#update {:format=>:json}
+#               v1_user_learning_target PATCH  /api/v1/user_learning_targets/:id(.:format)                                              v1/user_learning_targets#update {:format=>:json}
+#                                       PUT    /api/v1/user_learning_targets/:id(.:format)                                              v1/user_learning_targets#update {:format=>:json}
+#              v1_user_learning_targets GET    /api/v1/user_learning_targets(.:format)                                                  v1/user_learning_targets#show {:format=>:json}
 #                       v1_unit_masters POST   /api/v1/unit_masters(.:format)                                                           v1/unit_masters#create {:format=>:json}
 #                        v1_unit_master PATCH  /api/v1/unit_masters/:id(.:format)                                                       v1/unit_masters#update {:format=>:json}
 #                                       PUT    /api/v1/unit_masters/:id(.:format)                                                       v1/unit_masters#update {:format=>:json}
@@ -46,6 +49,8 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :masters, only: %i[index update show destroy create]
       resources :users, only: %i[create update]
+      resources :user_learning_targets, only: %i[update]
+      resource :user_learning_targets, only: %i[show]
       resources :unit_masters, only: %i[create update]
       resources :word_masters, only: %i[create update]
       resources :test_histories, only: %i[create]

--- a/db/migrate/20201123021656_create_user_learning_targets.rb
+++ b/db/migrate/20201123021656_create_user_learning_targets.rb
@@ -1,0 +1,11 @@
+class CreateUserLearningTargets < ActiveRecord::Migration[6.0]
+  def change
+    create_table :user_learning_targets do |t|
+      t.references :user, foreign_key: true
+
+      t.integer :target_learning_count, null: false, default: 0
+      t.integer :target_testing_count, null: false, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_23_013705) do
+ActiveRecord::Schema.define(version: 2020_11_23_021656) do
 
   create_table "learning_histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "word_master_id"
@@ -43,6 +43,15 @@ ActiveRecord::Schema.define(version: 2020_11_23_013705) do
     t.string "vietnamese", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "user_learning_targets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id"
+    t.integer "target_learning_count", default: 0, null: false
+    t.integer "target_testing_count", default: 0, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_user_learning_targets_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -79,5 +88,6 @@ ActiveRecord::Schema.define(version: 2020_11_23_013705) do
   add_foreign_key "learning_histories", "word_masters"
   add_foreign_key "test_histories", "users"
   add_foreign_key "test_histories", "word_masters"
+  add_foreign_key "user_learning_targets", "users"
   add_foreign_key "word_masters", "unit_masters"
 end

--- a/test/controllers/v1/user_learning_targets_controller_test.rb
+++ b/test/controllers/v1/user_learning_targets_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class V1::UserLearningTargetsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/user_learning_targets.yml
+++ b/test/fixtures/user_learning_targets.yml
@@ -1,0 +1,29 @@
+# == Schema Information
+#
+# Table name: user_learning_targets
+#
+#  id                    :bigint           not null, primary key
+#  target_learning_count :integer          default(0), not null
+#  target_testing_count  :integer          default(0), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  user_id               :bigint
+#
+# Indexes
+#
+#  index_user_learning_targets_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/user_learning_target_test.rb
+++ b/test/models/user_learning_target_test.rb
@@ -1,0 +1,26 @@
+# == Schema Information
+#
+# Table name: user_learning_targets
+#
+#  id                    :bigint           not null, primary key
+#  target_learning_count :integer          default(0), not null
+#  target_testing_count  :integer          default(0), not null
+#  created_at            :datetime         not null
+#  updated_at            :datetime         not null
+#  user_id               :bigint
+#
+# Indexes
+#
+#  index_user_learning_targets_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
+require 'test_helper'
+
+class UserLearningTargetTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 関連Issue
close #23 

## プルリクエストの概要
- [ ] ユーザーの学習の目標数を格納するuser_learning_targetsテーブルを作成
- [ ] ユーザー作成時に同時にuser_learning_targetsが生成されるように修正
- [ ] user_learning_targetsを取得出来るAPIを追加
- [ ] user_learning_targetsを更新出来るAPIを追加

## 実装の仕様
- [ ] user_learning_targetsを取得出来るAPI @GET /api/v1/user_learning_targets
**auth_token** 認証トークン

レスポンス
```
{
    "result": true,
    "message": "取得しました。",
    "id": 1,
    "target_learning_count": 30,
    "target_testing_count": 30,
    "created_at": "2020-11-23T11:29:31.822+09:00",
    "updated_at": "2020-11-23T11:29:31.822+09:00"
}
```

- [ ] user_learning_targetsを更新出来るAPIを追加
**auth_token** 認証トークン
**target_learning_count** 目標学習数の更新数
**target_testing_count** 目標テスト数の更新数

レスポンス
```
{
    "result": true,
    "message": "目標の更新に成功しました。"
}
```



## 関連情報
