### PR TITLE
単語一覧取得APIに学習済みかどうかのフラグを追加

### DIFF
--- a/app/controllers/v1/word_masters_controller.rb
+++ b/app/controllers/v1/word_masters_controller.rb
@@ -27,6 +27,7 @@ module V1
 
     def index
       @word_masters = WordMaster.where(unit_master_id: params[:unit_master_id])
+      @learned_history_ids = current_user.learning_histories.pluck(:word_master_id).uniq.map(&:to_s)
       render 'api/v1/word_masters/index', handlers: 'jbuilder'
     end
 

--- a/app/views/api/v1/word_masters/index.json.jbuilder
+++ b/app/views/api/v1/word_masters/index.json.jbuilder
@@ -9,5 +9,6 @@ json.word_masters @word_masters do |word_master|
   json.vietnamese word_master.vietnamese
   json.created_at word_master.created_at
   json.updated_at word_master.updated_at
+  json.is_learned @learned_history_ids.include? word_master.id.to_s
 end
 json.total_count @word_masters.count


### PR DESCRIPTION
## 関連Issue
close #31 

## プルリクエストの概要
- 単語一覧取得API(/api/v1/word_masters)に学習済みかどうかのフラグを追加

## 実装の仕様

## 関連情報
https://docs.google.com/spreadsheets/d/10gzB0q0QU-NRfc3CowHk0NhDlFM4kkv2d7CpngjRk0o/edit#gid=839470044