### PR TITLE
単元一覧取得APIに暗記済み数のカウントを返す

### DIFF
--- a/app/models/learning_history.rb
+++ b/app/models/learning_history.rb
@@ -24,4 +24,5 @@ class LearningHistory < ApplicationRecord
   belongs_to :word_master
 
   scope :created_today, -> { where('created_at >= ?', Time.zone.now.beginning_of_day) }
+  scope :is_remembered, -> { where(is_remember: true) }
 end

--- a/app/models/unit_master.rb
+++ b/app/models/unit_master.rb
@@ -14,4 +14,10 @@ class UnitMaster < ApplicationRecord
 
   validates :japanese, presence: true
   validates :vietnamese, presence: true
+
+  def memorized_word_count(current_user)
+    learning_histories = word_masters.pluck(:id).uniq
+    learned_word_ids = current_user.learning_histories.is_remembered.pluck(:word_master_id).uniq
+    (learned_word_ids & learning_histories).count
+  end
 end

--- a/app/views/api/v1/unit_masters/index.json.jbuilder
+++ b/app/views/api/v1/unit_masters/index.json.jbuilder
@@ -7,5 +7,6 @@ json.unit_masters @unit_masters do |unit_master|
   json.created_at unit_master.created_at
   json.updated_at unit_master.updated_at
   json.word_count unit_master.word_count
+  json.memorized_word_count unit_master.memorized_word_count current_user
 end
 json.total_count @unit_masters.count


### PR DESCRIPTION
## 関連Issue
close #39 

## プルリクエストの概要
単元一覧取得APIのレスポンスにmemorized_word_countを追加

## 実装の仕様

## 関連情報
https://docs.google.com/spreadsheets/d/10gzB0q0QU-NRfc3CowHk0NhDlFM4kkv2d7CpngjRk0o/edit#gid=134826807
