### PR TITLE
最新の覚えた単語に応じて覚えたかどうかを判定

### DIFF
--- a/app/models/learning_history.rb
+++ b/app/models/learning_history.rb
@@ -26,4 +26,5 @@ class LearningHistory < ApplicationRecord
   scope :created_today, -> { where('created_at >= ?', Time.zone.now.beginning_of_day) }
   scope :is_remembered, -> { where(is_remember: true) }
   scope :one_weeks, -> { where(created_at: 6.days.ago.beginning_of_day...Time.zone.now.end_of_day) }
+  scope :desc, -> { order(id: "DESC") }
 end

--- a/app/models/unit_master.rb
+++ b/app/models/unit_master.rb
@@ -17,7 +17,18 @@ class UnitMaster < ApplicationRecord
 
   def memorized_word_count(current_user)
     learning_histories = word_masters.pluck(:id).uniq
-    learned_word_ids = current_user.learning_histories.is_remembered.pluck(:word_master_id).uniq
-    (learned_word_ids & learning_histories).count
+    # learned_word_ids = current_user.learning_histories.is_remembered.pluck(:word_master_id).uniq
+    user_learning_histories = current_user.learning_histories.desc
+    remember_word_ids = []
+    not_remember_word_ids = []
+    user_learning_histories.each do |learned|
+      word_master_id = learned.word_master_id
+      if learned.is_remember && !remember_word_ids.include?(word_master_id) && !not_remember_word_ids.include?(word_master_id)
+        remember_word_ids << word_master_id
+      elsif !learned.is_remember && !remember_word_ids.include?(word_master_id) && !not_remember_word_ids.include?(word_master_id)
+        not_remember_word_ids << word_master_id
+      end
+    end
+    (remember_word_ids & learning_histories).count
   end
 end


### PR DESCRIPTION
## 関連Issue
close #48 

## プルリクエストの概要
今までは一度覚えた単語は覚えていないに登録しても覚えたことになっていたが、仕様を変更し覚えていないでカウントされるように変更した

## 実装の仕様

## 関連情報
